### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ Write markdown, get a slide deck. No BS. Or JS. Or HTML.
 
 Try it at http://deckdown.org
 
-##Usage
+## Usage
 
-###From Text
+### From Text
 Type or paste [markdown](http://daringfireball.net/projects/markdown/syntax) into the form above, and hit 'create deck'. Valid markdown will be parsed into a deck for you to enjoy. Deckdown currently doesn't save the markdown text that you submit to it so this is a one time, unique thing.
 
-###From A File
+### From A File
 Tell deckdown the url of your raw `.md` file by passing it as the `src` parameter, like this:
 
 ```
@@ -30,7 +30,7 @@ For example, here's a slideshow version of the [deckdown readme](http://deckdown
   
     Deckdown can take any publicly available url as an input for generating a slide deck. Links from your local filesystem that begin with `file:///` will not work. For that, just paste the contents of the file into deckdown a-la the *From Text* instructions above. 
 
-##Why use it?
+## Why use it?
 
 Deckdown is for breaking out of slideware jail. Traditional slideware is hard to proofread, and tweaking text size and alignment on large decks feels like a waste of time. I love reveal.js (it's used in this project), but the *process* of writing markup around my content in order to present it feels like a new flavor of the old slideware bloat. 
 
@@ -38,7 +38,7 @@ Deckdown changes all that by taking the contents of a single text file and turni
 
 Presentations that include code examples may never be the same. I hope you enjoy using deckdown.
 
-##How it works
+## How it works
 Deckdown breaks your markdown file into slides based on headers and horizontal rules. It does this with *regex*, and it splits up your file **after** converting it to html. This means html header tags `<h1> - <h6>` and `<hr>` become the slide delimiters. 
 
 When writing your markdown:
@@ -55,7 +55,7 @@ This Creates a New Slide
 
 Markdown conversion is done with [kramed](https://github.com/GitbookIO/kramed), and uses [GFM](https://help.github.com/articles/github-flavored-markdown) by default.  
 
-##Known issues
+## Known issues
 Deckdown is still in an early experimental state. Feel free to use it for your presentations if you wish, just know that sailing is not yet a smooth as it could be. Here are some of the bigger issues keeping deckdown from taking the world by storm:
 
   * Images
@@ -66,7 +66,7 @@ Deckdown is still in an early experimental state. Feel free to use it for your p
     Right now, it’s up to the markdown author to anticipate overflowing content, and to chunk accordingly. 
 
 
-##Contribute
+## Contribute
 Deckdown is on [github](http://github.com/alanguir/deckdown).
 
 Created 2014 by [Alan Languirand](http://github.com/alanguir/). [MIT license](/LICENSE).

--- a/public/examples/bella.md
+++ b/public/examples/bella.md
@@ -1,17 +1,17 @@
-##My Name is B. Carlson Esquire
+## My Name is B. Carlson Esquire
 
-##Life as a Dog
+## Life as a Dog
 My life is incredibly *challenging*.
 
-##Life as a Dog
+## Life as a Dog
 My humans sometimes feed me, but mostly they 
 
 let me ~~wither away~~ starve.
 
-##Life as a Dog
+## Life as a Dog
 One day, when I'm in charge, there will be never-ending amounts of food all throughout the land.
 
-##Plan for world domination
+## Plan for world domination
 
 1. Get free from the humans
 2. Eat **all** of the food

--- a/public/examples/deckdown.md
+++ b/public/examples/deckdown.md
@@ -1,14 +1,14 @@
-#Welcome to Deckdown
+# Welcome to Deckdown
 
-##Deckdown is
+## Deckdown is
 a brand new way to create slide decks
 
 ***
 It take a markdown file, and creates a _reveal.js_ powered slide deck
 
-##How?
+## How?
 
-##Markdown!
+## Markdown!
 
 ***
 
@@ -29,7 +29,7 @@ Deckdown slides are created anytime a new header `<h1>-<h6>` or horizontal rule 
 
 When creating a slid deck for _Deckdown_, just write markdown, and deckdown figures out the rest.
 
-###A Basic Deck
+### A Basic Deck
 
 Here is a basic deck, written in markdown. It creates two slides: 
 
@@ -41,9 +41,9 @@ Welcome to this presentation
 Stay in touch! alan@13protons.com
 ```
 
-##So, why make a deck using *Deckdown*?
+## So, why make a deck using *Deckdown*?
 
-#CODE!
+# CODE!
 
 Markdown makes it easy to write code, and even specify what language should be used to highlight the syntax 
 
@@ -63,7 +63,7 @@ Then specify it's language by adding it after the fence:
       var sum = var1 + var2;
     ```
 ``````
-####Here's some Java:
+#### Here's some Java:
 
 ```java
 public class Factorial
@@ -83,7 +83,7 @@ public class Factorial
 }
 ```
 
-####And Some C:
+#### And Some C:
 
 ```c
   #include<stdio.h>
@@ -103,7 +103,7 @@ public class Factorial
      return 0;
   }
 ```
-####Maybe some Phython?
+#### Maybe some Phython?
 
 ```python
   prices = {'apple': 0.40, 'banana': 0.50}
@@ -114,9 +114,9 @@ public class Factorial
   print 'I owe the grocer $%.2f' % grocery_bill
 ```
 
-###You get the point
+### You get the point
 
 ***
 View this document's [source code](https://gist.github.com/alanguir/db718cea7e23338bb3bc) to see more, and don't forget to read up on the [markdown spec](http://daringfireball.net/projects/markdown/syntax) for more info about how to write markdown. 
 
-#Happy Decking :)
+# Happy Decking :)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
